### PR TITLE
Bugfix/17 add add crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ If you don't have a github account feel free to contact us via mail at `jonasjur
 
 ## Changelog
 
+### 16.0.3
+* Added French translation
+* Fixed a bug where clicking add/edit twice would crash the game
+
 ### 16.0.2
 * Added sorting of tasks. Thanks to Tarrke for the reminder, input and code examples
 

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "Todo-List",
-  "version": "16.0.2",
+  "version": "16.0.3",
   "title": "Todo List",
   "author": "Jason Miles, Tessiema, Quis, Tarrke",
   "contact": "jonasjurczok+factorio@gmail.com",

--- a/src/todo/UI.lua
+++ b/src/todo/UI.lua
@@ -108,6 +108,10 @@ end
 function todo.create_add_edit_frame(player)
     local gui = player.gui.center
 
+    if (gui.todo_add_frame ~= nil) then
+        gui.todo_add_frame.destroy()
+    end
+
     local frame = gui.add({
         type = "frame",
         name = "todo_add_frame",
@@ -166,7 +170,7 @@ function todo.create_add_edit_frame(player)
         name = "todo_persist_button",
         caption = {"todo.persist"}
     })
-end
+    end
 
 function todo.add_task_to_table(table, task, completed, is_first, is_last)
     local prefix = ""

--- a/src/todo/UI.lua
+++ b/src/todo/UI.lua
@@ -170,7 +170,7 @@ function todo.create_add_edit_frame(player)
         name = "todo_persist_button",
         caption = {"todo.persist"}
     })
-    end
+end
 
 function todo.add_task_to_table(table, task, completed, is_first, is_last)
     local prefix = ""

--- a/src/todo/todo.lua
+++ b/src/todo/todo.lua
@@ -10,15 +10,15 @@ function todo.mod_init()
         global.todo = {["open"] = {}, ["done"] = {}, ["settings"] = {}}
     else
         for _, task in ipairs(global.todo.open) do
-          if not task.id then
-            task.id = todo.generate_id()
-          end
+            if not task.id then
+                task.id = todo.generate_id()
+            end
         end
 
         for _, task in ipairs(global.todo.done) do
-          if not task.id then
-            task.id = todo.generate_id()
-          end
+            if not task.id then
+                task.id = todo.generate_id()
+            end
         end
     end
 
@@ -89,11 +89,11 @@ function todo.get_task_from_add_frame(frame)
 end
 
 function todo.create_task(text, assignee)
-  local task = {}
-  task.id = todo.generate_id()
-  task.task = text
-  task.assignee = assignee
-  return task
+    local task = {}
+    task.id = todo.generate_id()
+    task.task = text
+    task.assignee = assignee
+    return task
 end
 
 function todo.edit_task(player, index)
@@ -191,7 +191,7 @@ function todo.toggle_show_completed(player)
         global.todo.settings[player.name] = {}
         global.todo.settings[player.name].show_completed = true
     else
-      global.todo.settings[player.name].show_completed = not global.todo.settings[player.name].show_completed
+        global.todo.settings[player.name].show_completed = not global.todo.settings[player.name].show_completed
     end
 
     local frame = todo.get_main_frame(player)


### PR DESCRIPTION
@Tarrke I fixed the issue in a much simpler way that also allows just clicking the edit button without having to close the dialog first. You can now freely switch tasks to edit/creating a new task.