### PR TITLE
Streamline the UI a bit

### DIFF
--- a/locale/de/locale.cfg
+++ b/locale/de/locale.cfg
@@ -24,7 +24,7 @@ hide_done=Verberge abgeschlossene Aufgaben
 todolist-toggle-ui=Todo Liste minimieren/maximieren
 
 [mod-setting-name]
-todolist-show-button=Zeige "Todo List" Schalter ins der mod ui.
+todolist-show-button=Zeige "Todo List" Schalter an/verstecke ihn
 todolist-show-log=Zeige debug Nachrichten im Chatfenster an.
 todolist-window-height=Fensterhöhe
 todolist-auto-assign=Auto-assign tasks

--- a/locale/de/locale.cfg
+++ b/locale/de/locale.cfg
@@ -24,13 +24,13 @@ hide_done=Verberge abgeschlossene Aufgaben
 todolist-toggle-ui=Todo Liste minimieren/maximieren
 
 [mod-setting-name]
-todolist-show-minimized=Zeige "Todo List" Schalter ins der mod ui.
+todolist-show-button=Zeige "Todo List" Schalter ins der mod ui.
 todolist-show-log=Zeige debug Nachrichten im Chatfenster an.
 todolist-window-height=Fensterhöhe
 todolist-auto-assign=Auto-assign tasks
 
 [mod-setting-description]
-todolist-show-minimized=Wenn aktiviert wird immer ein "Todo List" Schalter in der oberen linken Ecke angezeigt.\nWenn deaktiviert kann die Todo Liste nur über den Hotkey (standard shift+t) aufgerufen werden.
+todolist-show-button=Wenn aktiviert wird immer ein "Todo List" Schalter in der oberen linken Ecke angezeigt.\nWenn deaktiviert kann die Todo Liste nur über den Hotkey (standard shift+t) aufgerufen werden.
 todolist-show-log=Wenn aktiviert werden debug Nachrichten des mods im Chatfenster angezeigt.\nAchtung: Es sind sehr viele Nachrichten.
 todolist-window-height=Die Höhe des TodoList Fensters. Standard ist 600.
 todolist-auto-assign=If there is only one player in the game, auto-assign the task to this player.

--- a/locale/de/locale.cfg
+++ b/locale/de/locale.cfg
@@ -24,7 +24,7 @@ hide_done=Verberge abgeschlossene Aufgaben
 todolist-toggle-ui=Todo Liste minimieren/maximieren
 
 [mod-setting-name]
-todolist-show-button=Zeige "Todo List" Schalter an/verstecke ihn
+todolist-show-button=Zeige "Todo List" Schalter.
 todolist-show-log=Zeige debug Nachrichten im Chatfenster an.
 todolist-window-height=Fensterhöhe
 todolist-auto-assign=Auto-assign tasks

--- a/locale/de/locale.cfg
+++ b/locale/de/locale.cfg
@@ -24,7 +24,7 @@ hide_done=Verberge abgeschlossene Aufgaben
 todolist-toggle-ui=Todo Liste minimieren/maximieren
 
 [mod-setting-name]
-todolist-show-minimized=Zeige "Todo List" Schalter wenn minimiert.
+todolist-show-minimized=Zeige "Todo List" Schalter ins der mod ui.
 todolist-show-log=Zeige debug Nachrichten im Chatfenster an.
 todolist-window-height=Fensterhöhe
 todolist-auto-assign=Auto-assign tasks

--- a/locale/de/locale.cfg
+++ b/locale/de/locale.cfg
@@ -1,4 +1,5 @@
 [todo]
+todo_list=Todo List
 title_done=Status
 title_task=Aufgabe
 title_assignee=Zugewiesen an

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -1,4 +1,5 @@
 [todo]
+todo_list=Todo List
 title_done=Done
 title_task=Task
 title_assignee=Assignee

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -23,7 +23,7 @@ hide_done=Hide completed Tasks
 todolist-toggle-ui=Min/maximize todo list
 
 [mod-setting-name]
-todolist-show-button=Show "Todo List" button in mod ui.
+todolist-show-button=Show "Todo List" button.
 todolist-show-log=Show debug log messages in the chat window.
 todolist-window-height=Todo list window height
 todolist-auto-assign=Auto-assign tasks

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -23,7 +23,7 @@ hide_done=Hide completed Tasks
 todolist-toggle-ui=Min/maximize todo list
 
 [mod-setting-name]
-todolist-show-minimized=Show "Todo List" button when minimized.
+todolist-show-minimized=Show "Todo List" button in mod ui.
 todolist-show-log=Show debug log messages in the chat window.
 todolist-window-height=Todo list window height
 todolist-auto-assign=Auto-assign tasks

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -23,13 +23,13 @@ hide_done=Hide completed Tasks
 todolist-toggle-ui=Min/maximize todo list
 
 [mod-setting-name]
-todolist-show-minimized=Show "Todo List" button in mod ui.
+todolist-show-button=Show "Todo List" button in mod ui.
 todolist-show-log=Show debug log messages in the chat window.
 todolist-window-height=Todo list window height
 todolist-auto-assign=Auto-assign tasks
 
 [mod-setting-description]
-todolist-show-minimized=If enabled will always show a "Todo List" button in the top left.\nIf disabled the todo list can only be accessed by its hotkey (default shift-t).
+todolist-show-button=If enabled will always show a "Todo List" button in the top left.\nIf disabled the todo list can only be accessed by its hotkey (default shift-t).
 todolist-show-log=If enabled the mod will print debug messages to the chat window.\nAttention: there are a lot of them :)
 todolist-window-height=The height of the todo list window. Default is 600.
 todolist-auto-assign=If there is only one player in the game, auto-assign the task to this player.

--- a/locale/fr/locale.cfg
+++ b/locale/fr/locale.cfg
@@ -23,13 +23,13 @@ hide_done=Masquer les tâches finies
 todolist-toggle-ui=Minimiser/maximiser la liste
 
 [mod-setting-name]
-todolist-show-minimized=Afficher le bouton "Todo List" dans le mod ui.
+todolist-show-button=Afficher le bouton "Todo List" dans le mod ui.
 todolist-show-log=Afficher les messages de débugage dans la fenêtre de chat.
 todolist-window-height=Hauteur de la fenêtre des tâches
 todolist-auto-assign=Assigner automatiquement les tâches
 
 [mod-setting-description]
-todolist-show-minimized=Si actif le bouton "Todo List" sera toujours affiché dans le coin en haut à gauche.\nSi inactif la liste des tâches ne sera accessible que par le raccourcis clavier (par défaut shift-t).
+todolist-show-button=Si actif le bouton "Todo List" sera toujours affiché dans le coin en haut à gauche.\nSi inactif la liste des tâches ne sera accessible que par le raccourcis clavier (par défaut shift-t).
 todolist-show-log=Si actif le mod affichera ses messages de débugage dans la fenêtre de chat.\nAttention : il y en a beaucoup :)
 todolist-window-height=La taille de la fenêtre des tâches. Par défaut : 600.
 todolist-auto-assign=Si un seul joueur est dans la partie assigne par défaut la tâche à ce joueur.

--- a/locale/fr/locale.cfg
+++ b/locale/fr/locale.cfg
@@ -23,7 +23,7 @@ hide_done=Masquer les tâches finies
 todolist-toggle-ui=Minimiser/maximiser la liste
 
 [mod-setting-name]
-todolist-show-button=Afficher le bouton "Todo List" dans le mod ui.
+todolist-show-button=Afficher le bouton "Todo List".
 todolist-show-log=Afficher les messages de débugage dans la fenêtre de chat.
 todolist-window-height=Hauteur de la fenêtre des tâches
 todolist-auto-assign=Assigner automatiquement les tâches

--- a/locale/fr/locale.cfg
+++ b/locale/fr/locale.cfg
@@ -17,13 +17,13 @@ update=MAJ
 unassigned=Non Assignée
 assign_self=Prendre
 show_done=Montrer les tâches finies
-hide_done=Masquer les tâches finies 
+hide_done=Masquer les tâches finies
 
 [controls]
 todolist-toggle-ui=Minimiser/maximiser la liste
 
 [mod-setting-name]
-todolist-show-minimized=Afficher le bouton "Todo List" lorsque l'interface est minimisée.
+todolist-show-minimized=Afficher le bouton "Todo List" dans le mod ui.
 todolist-show-log=Afficher les messages de débugage dans la fenêtre de chat.
 todolist-window-height=Hauteur de la fenêtre des tâches
 todolist-auto-assign=Assigner automatiquement les tâches

--- a/locale/fr/locale.cfg
+++ b/locale/fr/locale.cfg
@@ -1,4 +1,5 @@
 [todo]
+todo_list=Todo List
 title_done=Terminé
 title_task=Tâche
 title_assignee=Joueur

--- a/locale/zh-CN/locale.cfg
+++ b/locale/zh-CN/locale.cfg
@@ -26,8 +26,10 @@ todolist-toggle-ui=最小化/最大化待办事项列表
 todolist-show-minimized=最小化时显示“待办事项列表”按钮。
 todolist-show-log=在聊天窗口中显示调试日志消息。
 todolist-window-height=待办事项列表窗口高度
+todolist-auto-assign=Auto-assign tasks
 
 [mod-setting-description]
 todolist-show-minimized=如果启用，将始终在左上角显示一个“待办事项列表”按钮。\n如果禁用，待办事项列表只能通过快捷键（默认shift-t）访问。
 todolist-show-log=如果启用，mod将打印调试消息到聊天窗口。\n注意：会有很多信息:)
 todolist-window-height=待办事项列表窗口的高度。 默认值是600。
+todolist-auto-assign=If there is only one player in the game, auto-assign the task to this player

--- a/locale/zh-CN/locale.cfg
+++ b/locale/zh-CN/locale.cfg
@@ -1,4 +1,5 @@
 [todo]
+todo_list=待办事项列表
 title_done=完成
 title_task=任务
 title_assignee=给予

--- a/locale/zh-CN/locale.cfg
+++ b/locale/zh-CN/locale.cfg
@@ -23,13 +23,13 @@ hide_done=隐藏已完成的任务
 todolist-toggle-ui=最小化/最大化待办事项列表
 
 [mod-setting-name]
-todolist-show-minimized=最小化时显示“待办事项列表”按钮。
+todolist-show-button=最小化时显示“待办事项列表”按钮。
 todolist-show-log=在聊天窗口中显示调试日志消息。
 todolist-window-height=待办事项列表窗口高度
 todolist-auto-assign=Auto-assign tasks
 
 [mod-setting-description]
-todolist-show-minimized=如果启用，将始终在左上角显示一个“待办事项列表”按钮。\n如果禁用，待办事项列表只能通过快捷键（默认shift-t）访问。
+todolist-show-button=如果启用，将始终在左上角显示一个“待办事项列表”按钮。\n如果禁用，待办事项列表只能通过快捷键（默认shift-t）访问。
 todolist-show-log=如果启用，mod将打印调试消息到聊天窗口。\n注意：会有很多信息:)
 todolist-window-height=待办事项列表窗口的高度。 默认值是600。
 todolist-auto-assign=If there is only one player in the game, auto-assign the task to this player

--- a/spec/UI_feature.lua
+++ b/spec/UI_feature.lua
@@ -8,9 +8,9 @@ feature("Testing the UI", function()
 
     scenario("The maximize button should persist when the UI is toggled", function()
         -- TODO: how to manipulate settings?
-        local temp = todo.show_minimized
+        local temp = todo.show_button
 
-        todo.show_minimized = function()
+        todo.show_button = function()
             return false
         end
 
@@ -22,6 +22,6 @@ feature("Testing the UI", function()
 
         assert(button ~= nil, "Maximize button not found!")
 
-        todo.show_minimized = temp
+        todo.show_button = temp
     end)
 end)

--- a/spec/UI_feature.lua
+++ b/spec/UI_feature.lua
@@ -6,7 +6,7 @@ feature("Testing the UI", function()
         assert(button ~= nil, "Maximize button not found!")
     end)
 
-    scenario("If maximize button should be hidden it should not be displayed.", function()
+    scenario("The maximize button should persist when the UI is toggled", function()
         -- TODO: how to manipulate settings?
         local temp = todo.show_minimized
 
@@ -20,7 +20,7 @@ feature("Testing the UI", function()
 
         local button = faketorio.find_element_by_id("todo_maximize_button", player)
 
-        assert(button == nil, "Maximize button found!")
+        assert(button ~= nil, "Maximize button not found!")
 
         todo.show_minimized = temp
     end)

--- a/spec/UI_spec.lua
+++ b/spec/UI_spec.lua
@@ -11,7 +11,7 @@ describe("UI tests", function()
 
   before_each(function()
 	faketorio.initialize_world_busted()
-    faketorio.add_default_setting("todolist-show-minimized", true)
+    faketorio.add_default_setting("todolist-show-button", true)
     faketorio.add_default_setting("todolist-show-log", false)
 	todo.mod_init()	
   end)

--- a/spec/task_spec.lua
+++ b/spec/task_spec.lua
@@ -11,7 +11,7 @@ describe("task tests", function()
 
   before_each(function()
     faketorio.initialize_world_busted()
-    faketorio.add_default_setting("todolist-show-minimized", true)
+    faketorio.add_default_setting("todolist-show-button", true)
     faketorio.add_default_setting("todolist-show-log", false)
     todo.mod_init()	
   end)

--- a/src/control.lua
+++ b/src/control.lua
@@ -30,3 +30,7 @@ script.on_event(defines.events.on_runtime_mod_setting_changed, function(event)
     local key = event.setting
     todo.on_runtime_mod_setting_changed(player, key)
 end)
+
+require("faketorio.core")
+
+require("faketorio.features.UI_feature")

--- a/src/control.lua
+++ b/src/control.lua
@@ -22,12 +22,7 @@ end)
 
 script.on_event("todolist-toggle-ui", function(event)
     local player = game.players[event.player_index]
-    if todo.get_main_frame(player) then
-        todo.minimize(player)
-    else
-        todo.maximize(player)
-        todo.refresh_task_table(player)
-    end
+    todo.toggle_ui(player)
 end)
 
 script.on_event(defines.events.on_runtime_mod_setting_changed, function(event)

--- a/src/control.lua
+++ b/src/control.lua
@@ -30,7 +30,3 @@ script.on_event(defines.events.on_runtime_mod_setting_changed, function(event)
     local key = event.setting
     todo.on_runtime_mod_setting_changed(player, key)
 end)
-
-require("faketorio.core")
-
-require("faketorio.features.UI_feature")

--- a/src/data.lua
+++ b/src/data.lua
@@ -1,3 +1,5 @@
+require('todo.style')
+
 local hotkey = {
     type = "custom-input",
     name = "todolist-toggle-ui",

--- a/src/settings.lua
+++ b/src/settings.lua
@@ -1,7 +1,7 @@
 data:extend({
 	{
 		type = "bool-setting",
-		name = "todolist-show-minimized",
+		name = "todolist-show-button",
 		setting_type = "runtime-per-user",
 		default_value = true,
 		per_user = true,

--- a/src/todo/UI.lua
+++ b/src/todo/UI.lua
@@ -147,11 +147,15 @@ function todo.create_add_edit_frame(player, task)
         caption = {"todo.add_task"}
     })
 
+    task_text = ""
+    if task then
+        task_text = task.task
+    end
     table.add({
         type = "text-box",
         style = "todo_textbox_default",
         name = "todo_new_task_textbox",
-        text = task and task.task or ""
+        text = task_text
     })
 
     table.add({
@@ -163,12 +167,10 @@ function todo.create_add_edit_frame(player, task)
 
     local players, lookup, c = todo.get_player_list()
     local assign_index = 1
-    if task then
-        assign_index = task.assignee and lookup[task.assignee] or 1
-    else
-        if( todo.is_auto_assign(player) and c == 1 ) then
-            assign_index = 2
-        end
+    if task and task.assignee then
+        assign_index = lookup[task.assignee]
+    elseif todo.is_auto_assign(player) and c == 1 then
+        assign_index = 2
     end
     table.add({
         type = "drop-down",

--- a/src/todo/UI.lua
+++ b/src/todo/UI.lua
@@ -147,7 +147,7 @@ function todo.create_add_edit_frame(player, task)
         caption = {"todo.add_task"}
     })
 
-    task_text = ""
+    local task_text = ""
     if task then
         task_text = task.task
     end

--- a/src/todo/UI.lua
+++ b/src/todo/UI.lua
@@ -120,7 +120,7 @@ end
 
 function todo.create_add_edit_frame(player, task)
     local gui = player.gui.center
-    local task = task or nil
+    task = task or nil
 
     if (gui.todo_add_frame ~= nil) then
         gui.todo_add_frame.destroy()
@@ -147,7 +147,7 @@ function todo.create_add_edit_frame(player, task)
         caption = {"todo.add_task"}
     })
 
-    local textbox = table.add({
+    table.add({
         type = "text-box",
         style = "todo_textbox_default",
         name = "todo_new_task_textbox",

--- a/src/todo/UI.lua
+++ b/src/todo/UI.lua
@@ -118,8 +118,9 @@ function todo.create_task_table(frame, player)
     return table
 end
 
-function todo.create_add_edit_frame(player)
+function todo.create_add_edit_frame(player, task)
     local gui = player.gui.center
+    local task = task or nil
 
     if (gui.todo_add_frame ~= nil) then
         gui.todo_add_frame.destroy()
@@ -149,7 +150,8 @@ function todo.create_add_edit_frame(player)
     local textbox = table.add({
         type = "text-box",
         style = "todo_textbox_default",
-        name = "todo_new_task_textbox"
+        name = "todo_new_task_textbox",
+        text = task and task.task or ""
     })
 
     table.add({
@@ -159,18 +161,21 @@ function todo.create_add_edit_frame(player)
         caption = {"todo.add_assignee"}
     })
 
-
-    local players, _, c = todo.get_player_list()
-    local index = 1
-    if( todo.is_auto_assign(player) and c == 1 ) then
-        index = 2
+    local players, lookup, c = todo.get_player_list()
+    local assign_index = 1
+    if task then
+        assign_index = task.assignee and lookup[task.assignee] or 1
+    else
+        if( todo.is_auto_assign(player) and c == 1 ) then
+            assign_index = 2
+        end
     end
     table.add({
         type = "drop-down",
         style = "todo_dropdown_default",
         name = "todo_add_assignee_drop_down",
         items = players,
-        selected_index = index
+        selected_index = assign_index
     })
 
     local flow = frame.add({
@@ -186,12 +191,21 @@ function todo.create_add_edit_frame(player)
         caption = {"todo.cancel"}
     })
 
-    flow.add({
-        type = "button",
-        style = "todo_button_default",
-        name = "todo_persist_button",
-        caption = {"todo.persist"}
-    })
+    if task then
+        flow.add({
+            type = "button",
+            style = "todo_button_default",
+            name = "todo_update_button_" .. task.id,
+            caption = {"todo.update"}
+        })
+    else
+        flow.add({
+            type = "button",
+            style = "todo_button_default",
+            name = "todo_persist_button",
+            caption = {"todo.persist"}
+        })
+    end
 end
 
 function todo.add_task_to_table(table, task, completed, is_first, is_last)
@@ -212,8 +226,7 @@ function todo.add_task_to_table(table, task, completed, is_first, is_last)
         type = "label",
         style = "todo_label_task",
         name = "todo_item_task_" .. id,
-        caption = task.task,
-        single_line = false
+        caption = task.task
     })
 
     if (task.assignee) then

--- a/src/todo/UI.lua
+++ b/src/todo/UI.lua
@@ -2,9 +2,12 @@
 function todo.create_minimized_button(player)
     todo.log("Creating Basic UI for player " .. player.name)
 
-    if not todo.get_maximize_button(player) and not todo.get_main_frame(player) and todo.show_minimized(player) then
+    if (not todo.get_maximize_button(player)
+      and not todo.get_main_frame(player)
+      and todo.show_minimized(player) ) then
         mod_gui.get_button_flow(player).add({
             type = "button",
+            style = "todo_button_default",
             name = "todo_maximize_button",
             caption = {"todo.todo_list"},
         })
@@ -29,12 +32,14 @@ function todo.create_maximized_frame(player)
 
     flow.add({
         type = "button",
+        style = "todo_button_default",
         name = "todo_add_button",
         caption = {"todo.add"}
     })
 
     flow.add({
         type = "button",
+        style = "todo_button_default",
         name = "todo_toggle_done_button",
         caption = {"todo.show_done"}
     })
@@ -42,6 +47,7 @@ function todo.create_maximized_frame(player)
     if todo.show_minimized(player) then
         flow.add({
             type = "button",
+            style = "todo_button_default",
             name = "todo_minimize_button",
             caption = {"todo.minimize"}
         })
@@ -62,42 +68,49 @@ function todo.create_task_table(frame, player)
 
     local table = scroll.add({
         type = "table",
+        style = "todo_table_default",
         name = "todo_task_table",
         column_count = 6
     })
 
     table.add({
         type = "label",
+        style = "todo_label_default",
         name = "todo_title_done",
         caption = {"", {"todo.title_done"}, "   "}
     })
 
     table.add({
         type = "label",
+        style = "todo_label_default",
         name = "todo_title_task",
         caption = {"todo.title_task"}
     })
 
     table.add({
         type = "label",
+        style = "todo_label_default",
         name = "todo_title_assignee",
         caption = {"todo.title_assignee"}
     })
 
     table.add({
         type = "label",
+        style = "todo_label_default",
         name = "todo_title_up",
         caption = ""
     })
 
     table.add({
         type = "label",
+        style = "todo_label_default",
         name = "todo_title_down",
         caption = ""
     })
 
     table.add({
         type = "label",
+        style = "todo_label_default",
         name = "todo_title_edit",
         caption = ""
     })
@@ -121,25 +134,27 @@ function todo.create_add_edit_frame(player)
 
     local table = frame.add({
         type = "table",
+        style = "todo_table_default",
         name = "todo_add_task_table",
         column_count = 2
     })
 
     table.add({
         type = "label",
+        style = "todo_label_default",
         name = "todo_add_task_label",
         caption = {"todo.add_task"}
     })
 
     local textbox = table.add({
         type = "text-box",
+        style = "todo_textbox_default",
         name = "todo_new_task_textbox"
     })
-    textbox.style.minimal_width = 300
-    textbox.style.minimal_height = 100
 
     table.add({
         type = "label",
+        style = "todo_label_default",
         name = "todo_add_assignee_label",
         caption = {"todo.add_assignee"}
     })
@@ -152,6 +167,7 @@ function todo.create_add_edit_frame(player)
     end
     table.add({
         type = "drop-down",
+        style = "todo_dropdown_default",
         name = "todo_add_assignee_drop_down",
         items = players,
         selected_index = index
@@ -165,12 +181,14 @@ function todo.create_add_edit_frame(player)
 
     flow.add({
         type = "button",
+        style = "todo_button_default",
         name = "todo_cancel_button",
         caption = {"todo.cancel"}
     })
 
     flow.add({
         type = "button",
+        style = "todo_button_default",
         name = "todo_persist_button",
         caption = {"todo.persist"}
     })
@@ -192,6 +210,7 @@ function todo.add_task_to_table(table, task, completed, is_first, is_last)
 
     table.add({
         type = "label",
+        style = "todo_label_task",
         name = "todo_item_task_" .. id,
         caption = task.task,
         single_line = false
@@ -200,12 +219,14 @@ function todo.add_task_to_table(table, task, completed, is_first, is_last)
     if (task.assignee) then
         table.add({
             type = "label",
+            style = "todo_label_default",
             name = "todo_item_assignee_" .. id,
             caption = task.assignee
         })
     else
         table.add({
             type = "button",
+            style = "todo_button_default",
             name = "todo_item_assign_self_" .. id,
             caption = {"todo.assign_self"}
         })
@@ -220,6 +241,7 @@ function todo.add_task_to_table(table, task, completed, is_first, is_last)
     else
         table.add({
             type = "button",
+            style = "todo_button_default",
             name = "todo_item_up_" .. id,
             caption = "↑"
         })
@@ -234,6 +256,7 @@ function todo.add_task_to_table(table, task, completed, is_first, is_last)
     else
         table.add({
             type = "button",
+            style = "todo_button_default",
             name = "todo_item_down_" .. id,
             caption = "↓"
         })
@@ -241,8 +264,8 @@ function todo.add_task_to_table(table, task, completed, is_first, is_last)
 
     table.add({
         type = "button",
+        style = "todo_button_default",
         name = "todo_item_edit_" .. id,
         caption = {"todo.title_edit"}
     })
-
 end

--- a/src/todo/UI.lua
+++ b/src/todo/UI.lua
@@ -4,7 +4,7 @@ function todo.create_minimized_button(player)
 
     if (not todo.get_maximize_button(player)
       and not todo.get_main_frame(player)
-      and todo.show_minimized(player) ) then
+      and todo.show_button(player) ) then
         mod_gui.get_button_flow(player).add({
             type = "button",
             style = "todo_button_default",
@@ -44,7 +44,7 @@ function todo.create_maximized_frame(player)
         caption = {"todo.show_done"}
     })
 
-    if todo.show_minimized(player) then
+    if todo.show_button(player) then
         flow.add({
             type = "button",
             style = "todo_button_default",

--- a/src/todo/UI.lua
+++ b/src/todo/UI.lua
@@ -6,7 +6,7 @@ function todo.create_minimized_button(player)
         mod_gui.get_button_flow(player).add({
             type = "button",
             name = "todo_maximize_button",
-            caption = "Todo List"
+            caption = {"todo.todo_list"},
         })
     end
 end
@@ -15,7 +15,7 @@ function todo.create_maximized_frame(player)
     local frame = mod_gui.get_frame_flow(player).add({
         type = "frame",
         name = "todo_main_frame",
-        caption = "Todo List",
+        caption = {"todo.todo_list"},
         direction = "vertical"
     })
 

--- a/src/todo/UI.lua
+++ b/src/todo/UI.lua
@@ -166,6 +166,7 @@ function todo.create_add_edit_frame(player, task)
     })
 
     local players, lookup, c = todo.get_player_list()
+
     local assign_index = 1
     if task and task.assignee then
         assign_index = lookup[task.assignee]

--- a/src/todo/helper.lua
+++ b/src/todo/helper.lua
@@ -61,8 +61,8 @@ function todo.get_task_table(player)
     end
 end
 
-function todo.show_minimized(player)
-    return settings.get_player_settings(player)["todolist-show-minimized"].value
+function todo.show_button(player)
+    return settings.get_player_settings(player)["todolist-show-button"].value
 end
 
 function todo.is_auto_assign(player)

--- a/src/todo/helper.lua
+++ b/src/todo/helper.lua
@@ -1,6 +1,5 @@
 
 function todo.log(message)
-    log(message)
     if game then
         for _, p in pairs(game.players) do
             if (todo.show_log(p)) then

--- a/src/todo/helper.lua
+++ b/src/todo/helper.lua
@@ -1,5 +1,6 @@
 
 function todo.log(message)
+    log(message)
     if game then
         for _, p in pairs(game.players) do
             if (todo.show_log(p)) then

--- a/src/todo/style.lua
+++ b/src/todo/style.lua
@@ -1,0 +1,45 @@
+local default_gui = data.raw["gui-style"].default
+
+
+data:extend({
+  {
+    type = "font",
+    name = "todo_font_default",
+    from = "default",
+    size = 14
+  },
+})
+
+default_gui["todo_table_default"] = {
+  type = "table_style",
+}
+
+default_gui["todo_button_default"] = {
+  type = "button_style",
+  font = "todo_font_default",
+  align = "center",
+  vertical_align = "center"
+}
+
+default_gui["todo_label_default"] = {
+  type = "label_style",
+  font = "todo_font_default",
+}
+
+default_gui["todo_label_task"] = {
+  type = "label_style",
+  font = "todo_font_default",
+  single_line = false
+}
+
+default_gui["todo_textbox_default"] = {
+  type = "textbox_style",
+  font = "todo_font_default",
+  minimal_width = 300,
+  minimal_height = 100,
+}
+
+default_gui["todo_dropdown_default"] = {
+  type = "dropdown_style",
+  font = "todo_font_default",
+}

--- a/src/todo/todo.lua
+++ b/src/todo/todo.lua
@@ -251,8 +251,8 @@ function todo.on_gui_click(event)
         local id = todo.get_task_id_from_element_name(element.name, "todo_item_down_")
         todo.move_down(id)
         todo.update_task_table()
-    else
-        todo.log("Unknown element name:" .. element.name)
+    elseif (string.find(element.name, "todo_")) then
+        todo.log("Unknown todo element name:" .. element.name)
     end
 end
 

--- a/src/todo/todo.lua
+++ b/src/todo/todo.lua
@@ -31,16 +31,10 @@ function todo.minimize(player)
     todo.log("Minimizing UI for player " .. player.name)
 
     todo.get_main_frame(player).destroy()
-    todo.create_minimized_button(player)
 end
 
 function todo.maximize(player)
     todo.log("Maximizing UI for player " .. player.name)
-
-    local max_button = todo.get_maximize_button(player)
-    if max_button then
-        max_button.destroy()
-    end
 
     todo.create_maximized_frame(player)
 end

--- a/src/todo/todo.lua
+++ b/src/todo/todo.lua
@@ -27,6 +27,15 @@ function todo.mod_init()
     end
 end
 
+function todo.toggle_ui(player)
+  if todo.get_main_frame(player) then
+    todo.minimize(player)
+  else
+    todo.maximize(player)
+    todo.refresh_task_table(player)
+  end
+end
+
 function todo.minimize(player)
     todo.log("Minimizing UI for player " .. player.name)
 
@@ -220,8 +229,7 @@ function todo.on_gui_click(event)
     local element = event.element
 
     if (element.name == "todo_maximize_button") then
-        todo.maximize(player)
-        todo.refresh_task_table(player)
+        todo.toggle_ui(player)
     elseif (element.name == "todo_minimize_button") then
         todo.minimize(player)
     elseif (element.name == "todo_add_button") then

--- a/src/todo/todo.lua
+++ b/src/todo/todo.lua
@@ -99,32 +99,6 @@ function todo.create_task(text, assignee)
     return task
 end
 
-function todo.edit_task(player, index)
-    todo.create_add_edit_frame(player)
-
-    local task = todo.get_task_by_id(index)
-    local players, lookup = todo.get_player_list()
-    local table = player.gui.center.todo_add_frame.todo_add_task_table
-
-    table.children[2].text = task.task
-
-    table.children[4].items = players
-    if (task.assignee) then
-        table.children[4].selected_index = lookup[task.assignee]
-    else
-        table.children[4].selected_index = 0
-    end
-
-    local flow = table.parent.todo_add_button_flow
-    flow.todo_persist_button.destroy()
-
-    flow.add({
-        type = "button",
-        name = "todo_update_button_" .. index,
-        caption = {"todo.update"}
-    })
-end
-
 function todo.update_task_table()
     for _, player in pairs(game.players) do
         todo.refresh_task_table(player)
@@ -246,8 +220,8 @@ function todo.on_gui_click(event)
         todo.update_task_table()
     elseif (string.find(element.name, "todo_item_edit_")) then
         local id = todo.get_task_id_from_element_name(element.name, "todo_item_edit_")
-
-        todo.edit_task(player, id)
+        local task = todo.get_task_by_id(id)
+        todo.create_add_edit_frame(player, task)
     elseif (string.find(element.name, "todo_update_button_")) then
         local id = todo.get_task_id_from_element_name(element.name, "todo_update_button_")
 

--- a/src/todo/todo.lua
+++ b/src/todo/todo.lua
@@ -257,8 +257,8 @@ function todo.on_gui_click(event)
 end
 
 function todo.on_runtime_mod_setting_changed(player, key)
-    if (key == "todolist-show-minimized") then
-        todo.on_show_minimized_changed(player)
+    if (key == "todolist-show-button") then
+        todo.on_show_button_changed(player)
     elseif (key == "todolist-show-log") then
         todo.log("Updated logging settings for player " .. player.name)
     elseif (key == "todolist-auto-assign") then
@@ -266,8 +266,8 @@ function todo.on_runtime_mod_setting_changed(player, key)
     end
 end
 
-function todo.on_show_minimized_changed(player)
-    if todo.show_minimized(player) then
+function todo.on_show_button_changed(player)
+    if todo.show_button(player) then
         todo.log("Showing minimized button.")
         if not todo.get_maximize_button(player) then
             todo.create_minimized_button(player)


### PR DESCRIPTION
refs #41 

While working on #40, (and, well, learning how 2 lua), I made some changes that I think improve the user and development experience.

I haven't run the faketorio tests yet, mainly because I don't know how, and didn't really have internet access while working on these, so I suppose I should probably do that too.

Anyways, run down of the changes:

Main changes:
- Localize the main todo button
- Add explicit styles for UI elements, and use them
- Change the 'show button when minimized' setting to just always show the button
- Main Todo List button now toggles the UI, just like the hotkey
- Unify add and edit UIs
- Move add/edit UI init into UI module

QOL:
- ~todo.log also logs to main log~ Removed because lint doesn't like it and I don't think I can change the travis config to allow it. Also, not really super helpful.

fixes:
- Add chinese localization entries for auto-assign (in english, but at least they're there?)
- squelch the 'unknown element' warning when a non-todo gui element is clicked.

See in-line github comments for some more detailed explanations. (still coming)

Screenshots!

Before:
<img width="954" alt="screenshot 2018-08-06 16 04 39" src="https://user-images.githubusercontent.com/569403/43738652-5bd7ca2c-9993-11e8-9a9c-b6cb0ebe7b28.png">

After:
<img width="1140" alt="screenshot 2018-08-06 15 51 03" src="https://user-images.githubusercontent.com/569403/43738700-876ac07c-9993-11e8-978c-f145840f4413.png">
