### PR TITLE
Move to top or bottom buttons

### DIFF
--- a/locale/de/locale.cfg
+++ b/locale/de/locale.cfg
@@ -7,9 +7,10 @@ title_edit=Bearbeiten
 
 minimize=Minimieren
 add=Neue Aufgabe
-add_title=Neue Aufgabe anlegen
-add_task=Aufgabe
 add_assignee=Bearbeiter
+add_task=Aufgabe
+add_title=Neue Aufgabe anlegen
+add_top=[Add to top]
 persist=Speichern
 cancel=Abbrechen
 update=Speichern

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -10,9 +10,12 @@ add=Add new
 add_title=Add new task
 add_task=Task
 add_assignee=Assignee
+add_where=Add Where
 persist=Save
 cancel=Cancel
 update=Update
+top=Top
+bottom=Bottom
 
 unassigned=Unassigned
 assign_self=Take

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -7,14 +7,14 @@ title_edit=Edit
 
 minimize=Minimize
 add=Add new
-add_title=Add new task
 add_task=Task
+add_title=Add new task
+add_top=Add to Top
 add_assignee=Assignee
 add_where=Add Where
 persist=Save
 cancel=Cancel
 update=Update
-top=Top
 bottom=Bottom
 
 unassigned=Unassigned

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -7,11 +7,10 @@ title_edit=Edit
 
 minimize=Minimize
 add=Add new
+add_assignee=Assignee
 add_task=Task
 add_title=Add new task
 add_top=Add to Top
-add_assignee=Assignee
-add_where=Add Where
 persist=Save
 cancel=Cancel
 update=Update

--- a/locale/fr/locale.cfg
+++ b/locale/fr/locale.cfg
@@ -7,9 +7,10 @@ title_edit=Editer
 
 minimize=Minimiser
 add=Nouvelle Tâche
-add_title=Ajouter Nouvelle Tâche
-add_task=Tâche
 add_assignee=Personne
+add_task=Tâche
+add_title=Ajouter Nouvelle Tâche
+add_top=[Add to Top]
 persist=Enregistrer
 cancel=Annuler
 update=MAJ

--- a/locale/zh-CN/locale.cfg
+++ b/locale/zh-CN/locale.cfg
@@ -7,9 +7,10 @@ title_edit=编辑
 
 minimize=最小化面板
 add=添加新任务
-add_title=添加新任务
-add_task=任务
 add_assignee=给予
+add_task=任务
+add_title=添加新任务
+add_top=Add to Top
 persist=保存
 cancel=取消
 update=更新

--- a/spec/UI_feature.lua
+++ b/spec/UI_feature.lua
@@ -1,3 +1,11 @@
+local task_num = 1
+function add_task(task)
+    task = task or 'this is a task ' .. task_num
+    task_num = task_num + 1
+
+    return task
+end
+
 feature("Testing the UI", function()
     scenario("initially the maximize button should be displayed.", function()
         local player = game.players[1]
@@ -7,14 +15,16 @@ feature("Testing the UI", function()
     end)
 
     scenario("The maximize button should persist when the UI is toggled", function()
-        -- TODO: how to manipulate settings?
-        local temp = todo.show_button
+        -- Ensure the UI is closed
+        local player = game.players[1]
+        todo.minimize(player)
 
+        -- Mock out the 'show_button' function
+        local temp = todo.show_button
         todo.show_button = function()
             return false
         end
 
-        local player = game.players[1]
         todo.maximize(player)
         todo.minimize(player)
 
@@ -22,6 +32,18 @@ feature("Testing the UI", function()
 
         assert(button ~= nil, "Maximize button not found!")
 
+        -- replade the 'show_button' mock
         todo.show_button = temp
+    end)
+
+    scenario("Checking 'Add to top' when creating a task should add it to the top of the list", function()
+        log('added task ' .. add_task())
+        log('added task ' .. add_task())
+        log('added task ' .. add_task())
+        log('added task ' .. add_task())
+        -- Open the todo list
+        -- Click 'add new task'
+        -- enter some text
+        --
     end)
 end)

--- a/spec/UI_feature.lua
+++ b/spec/UI_feature.lua
@@ -1,7 +1,10 @@
 local task_num = 1
-function add_task(task)
-    task = task or 'this is a task ' .. task_num
+function add_task(text)
+    text = text or 'this is a task ' .. task_num
     task_num = task_num + 1
+
+    local task = todo.create_task(text)
+    todo.save_task(task)
 
     return task
 end
@@ -36,14 +39,45 @@ feature("Testing the UI", function()
         todo.show_button = temp
     end)
 
-    scenario("Checking 'Add to top' when creating a task should add it to the top of the list", function()
-        log('added task ' .. add_task())
-        log('added task ' .. add_task())
-        log('added task ' .. add_task())
-        log('added task ' .. add_task())
-        -- Open the todo list
-        -- Click 'add new task'
-        -- enter some text
-        --
+    scenario('Clicking the double up button moves that task to the top', function()
+        local player = game.players[1]
+        add_task()
+        middle_task = add_task('middle')
+        bottom_task = add_task('at the bottom')
+
+        todo.minimize(player)
+        todo.maximize(player)
+        todo.refresh_task_table(player)
+
+        faketorio.click('todo_item_top_' .. bottom_task.id)
+
+        assert(global.todo.open[1].task == 'at the bottom')
+
+        faketorio.click('todo_item_top_' .. middle_task.id)
+
+        assert(global.todo.open[1].task == 'middle')
+        assert(global.todo.open[2].task == 'at the bottom')
     end)
+    -- scenario("Checking 'Add to top' when creating a task should add it to the top of the list", function()
+    --     add_task()
+    --     add_task()
+    --     add_task()
+
+    --     faketorio.click('todo_maximize_button')
+
+    --     -- Add a task to the bottom
+    --     faketorio.click('todo_add_button')
+    --     faketorio.enter_text('todo_new_task_textbox', 'task for the bottom')
+    --     faketorio.click('todo_persist_button')
+
+    --     -- Add a task to the top
+    --     faketorio.click('todo_add_button')
+    --     faketorio.enter_text('todo_new_task_textbox', 'task for the top')
+    --     faketorio.click('todo_add_top')
+    --     -- faketorio.click('todo_persist_button')
+
+    --     assert(global.todo.open[5].task == 'task for the bottom')
+    --     assert(global.todo.open[1].task == 'task for the top')
+
+    -- end)
 end)

--- a/spec/UI_feature.lua
+++ b/spec/UI_feature.lua
@@ -35,7 +35,7 @@ feature("Testing the UI", function()
 
         assert(button ~= nil, "Maximize button not found!")
 
-        -- replade the 'show_button' mock
+        -- replace the 'show_button' mock
         todo.show_button = temp
     end)
 

--- a/src/todo/UI.lua
+++ b/src/todo/UI.lua
@@ -222,27 +222,12 @@ function todo.create_add_edit_frame(player, task)
             name = "todo_persist_button",
             caption = {"todo.persist"}
         })
-        local add_where_frame = flow.add({
-            type = "frame",
-            style = "todo_frame_add_where",
-            name = "todo_add_where_frame",
-            caption = {"todo.add_where"}
-        })
-
-        add_where_frame.add({
-            type = "radiobutton",
-            style = "todo_radiobutton_default",
+        flow.add({
+            type = "checkbox",
+            style = "todo_checkbox_default",
             name = "todo_add_top",
             state = false,
-            caption = {"todo.top"}
-        })
-
-        add_where_frame.add({
-            type = "radiobutton",
-            style = "todo_radiobutton_default",
-            name = "todo_add_bottom",
-            state = true,
-            caption = {"todo.bottom"}
+            caption = {"todo.add_top"}
         })
     end
 end

--- a/src/todo/UI.lua
+++ b/src/todo/UI.lua
@@ -70,7 +70,7 @@ function todo.create_task_table(frame, player)
         type = "table",
         style = "todo_table_default",
         name = "todo_task_table",
-        column_count = 6
+        column_count = 8,
     })
 
     table.add({
@@ -104,7 +104,21 @@ function todo.create_task_table(frame, player)
     table.add({
         type = "label",
         style = "todo_label_default",
+        name = "todo_title_top",
+        caption = ""
+    })
+
+    table.add({
+        type = "label",
+        style = "todo_label_default",
         name = "todo_title_down",
+        caption = ""
+    })
+
+    table.add({
+        type = "label",
+        style = "todo_label_default",
+        name = "todo_title_bottom",
         caption = ""
     })
 
@@ -254,12 +268,23 @@ function todo.add_task_to_table(table, task, completed, is_first, is_last)
             name = "todo_item_firstup_" .. id,
             caption = ""
         })
+        table.add({
+            type = "label",
+            name = "todo_item_firsttop_" .. id,
+            caption = ""
+        })
     else
         table.add({
             type = "button",
             style = "todo_button_default",
             name = "todo_item_up_" .. id,
             caption = "↑"
+        })
+        table.add({
+            type = "button",
+            style = "todo_button_default",
+            name = "todo_item_top_" .. id,
+            caption = "↟"
         })
     end
 
@@ -269,12 +294,23 @@ function todo.add_task_to_table(table, task, completed, is_first, is_last)
             name = "todo_item_lastdown_" .. id,
             caption = ""
         })
+        table.add({
+            type = "label",
+            name = "todo_item_lastbottom_" .. id,
+            caption = ""
+        })
     else
         table.add({
             type = "button",
             style = "todo_button_default",
             name = "todo_item_down_" .. id,
             caption = "↓"
+        })
+        table.add({
+            type = "button",
+            style = "todo_button_default",
+            name = "todo_item_bottom_" .. id,
+            caption = "↡"
         })
     end
 

--- a/src/todo/UI.lua
+++ b/src/todo/UI.lua
@@ -222,6 +222,28 @@ function todo.create_add_edit_frame(player, task)
             name = "todo_persist_button",
             caption = {"todo.persist"}
         })
+        local add_where_frame = flow.add({
+            type = "frame",
+            style = "todo_frame_add_where",
+            name = "todo_add_where_frame",
+            caption = {"todo.add_where"}
+        })
+
+        add_where_frame.add({
+            type = "radiobutton",
+            style = "todo_radiobutton_default",
+            name = "todo_add_top",
+            state = false,
+            caption = {"todo.top"}
+        })
+
+        add_where_frame.add({
+            type = "radiobutton",
+            style = "todo_radiobutton_default",
+            name = "todo_add_bottom",
+            state = true,
+            caption = {"todo.bottom"}
+        })
     end
 end
 

--- a/src/todo/UI.lua
+++ b/src/todo/UI.lua
@@ -97,14 +97,14 @@ function todo.create_task_table(frame, player)
     table.add({
         type = "label",
         style = "todo_label_default",
-        name = "todo_title_up",
+        name = "todo_title_top",
         caption = ""
     })
 
     table.add({
         type = "label",
         style = "todo_label_default",
-        name = "todo_title_top",
+        name = "todo_title_up",
         caption = ""
     })
 
@@ -272,26 +272,26 @@ function todo.add_task_to_table(table, task, completed, is_first, is_last)
     if (is_first) then
         table.add({
             type = "label",
-            name = "todo_item_firstup_" .. id,
+            name = "todo_item_firsttop_" .. id,
             caption = ""
         })
         table.add({
             type = "label",
-            name = "todo_item_firsttop_" .. id,
+            name = "todo_item_firstup_" .. id,
             caption = ""
         })
     else
         table.add({
             type = "button",
             style = "todo_button_default",
-            name = "todo_item_up_" .. id,
-            caption = "↑"
+            name = "todo_item_top_" .. id,
+            caption = "↟"
         })
         table.add({
             type = "button",
             style = "todo_button_default",
-            name = "todo_item_top_" .. id,
-            caption = "↟"
+            name = "todo_item_up_" .. id,
+            caption = "↑"
         })
     end
 

--- a/src/todo/helper.lua
+++ b/src/todo/helper.lua
@@ -82,7 +82,6 @@ function todo.show_log(player)
 end
 
 function todo.get_task_id_from_element_name(name, pattern)
-    -- TODO: This probably doesn't need the pattern, just split on the last _
     local _, start = string.find(name, pattern)
     local index = tonumber(string.sub(name, start + 1))
     return index

--- a/src/todo/helper.lua
+++ b/src/todo/helper.lua
@@ -114,7 +114,7 @@ function todo.filter_table_by_id(source, exclude_id, destination)
     destination = destination or {}
     local i = #destination
 
-    for index, task in pairs(source) do
+    for _, task in pairs(source) do
         if (task.id ~= exclude_id) then
             i = i + 1
             destination[i] = task

--- a/src/todo/helper.lua
+++ b/src/todo/helper.lua
@@ -1,5 +1,10 @@
 
 function todo.log(message)
+    if type(message) == 'table' then
+        message = serpent.dump(message) .. ' [' .. #message .. ']'
+    end
+    message = "" .. message or '<nil>'
+
     if game then
         for _, p in pairs(game.players) do
             if (todo.show_log(p)) then
@@ -77,6 +82,7 @@ function todo.show_log(player)
 end
 
 function todo.get_task_id_from_element_name(name, pattern)
+    -- TODO: This probably doesn't need the pattern, just split on the last _
     local _, start = string.find(name, pattern)
     local index = tonumber(string.sub(name, start + 1))
     return index

--- a/src/todo/helper.lua
+++ b/src/todo/helper.lua
@@ -110,3 +110,17 @@ function todo.get_task_by_id(id)
     end
   end
 end
+
+function todo.filter_table_by_id(source, exclude_id, destination)
+    destination = destination or {}
+    local i = #destination
+
+    for index, task in pairs(source) do
+        if (task.id ~= exclude_id) then
+            i = i + 1
+            destination[i] = task
+        end
+    end
+
+    return destination
+end

--- a/src/todo/style.lua
+++ b/src/todo/style.lua
@@ -2,44 +2,63 @@ local default_gui = data.raw["gui-style"].default
 
 
 data:extend({
-  {
-    type = "font",
-    name = "todo_font_default",
-    from = "default",
-    size = 14
-  },
+    {
+        type = "font",
+        name = "todo_font_default",
+        from = "default",
+        size = 14
+    },
+})
+
+data:extend({
+    {
+        type = "font",
+        name = "todo_font_subheading",
+        from = "default",
+        size = 18
+    }
 })
 
 default_gui["todo_table_default"] = {
-  type = "table_style",
+    type = "table_style",
 }
 
 default_gui["todo_button_default"] = {
-  type = "button_style",
-  font = "todo_font_default",
-  align = "center",
-  vertical_align = "center"
+    type = "button_style",
+    font = "todo_font_default",
+    align = "center",
+    vertical_align = "center"
 }
 
 default_gui["todo_label_default"] = {
-  type = "label_style",
-  font = "todo_font_default",
+    type = "label_style",
+    font = "todo_font_default",
 }
 
 default_gui["todo_label_task"] = {
-  type = "label_style",
-  font = "todo_font_default",
-  single_line = false
+    type = "label_style",
+    font = "todo_font_default",
+    single_line = false
 }
 
 default_gui["todo_textbox_default"] = {
-  type = "textbox_style",
-  font = "todo_font_default",
-  minimal_width = 300,
-  minimal_height = 100,
+    type = "textbox_style",
+    font = "todo_font_default",
+    minimal_width = 300,
+    minimal_height = 100,
 }
 
 default_gui["todo_dropdown_default"] = {
-  type = "dropdown_style",
-  font = "todo_font_default",
+    type = "dropdown_style",
+    font = "todo_font_default",
+}
+
+default_gui["todo_frame_add_where"] = {
+    type = "frame_style",
+    font = "todo_font_subheading"
+}
+
+default_gui["todo_radiobutton_default"] = {
+    type = "radiobutton_style",
+    font = "todo_font_default"
 }

--- a/src/todo/style.lua
+++ b/src/todo/style.lua
@@ -58,6 +58,11 @@ default_gui["todo_frame_add_where"] = {
     font = "todo_font_subheading"
 }
 
+default_gui["todo_checkbox_default"] = {
+    type = "checkbox_style",
+    font = "todo_font_default"
+}
+
 default_gui["todo_radiobutton_default"] = {
     type = "radiobutton_style",
     font = "todo_font_default"

--- a/src/todo/todo.lua
+++ b/src/todo/todo.lua
@@ -39,13 +39,22 @@ end
 function todo.minimize(player)
     todo.log("Minimizing UI for player " .. player.name)
 
-    todo.get_main_frame(player).destroy()
+    local frame = todo.get_main_frame(player)
+    if frame then
+        frame.destroy()
+        return true
+    end
+    return false
 end
 
 function todo.maximize(player)
     todo.log("Maximizing UI for player " .. player.name)
 
-    todo.create_maximized_frame(player)
+    if not todo.get_main_frame(player) then
+        todo.create_maximized_frame(player)
+        return true
+    end
+    return false
 end
 
 function todo.persist(element)

--- a/src/todo/todo.lua
+++ b/src/todo/todo.lua
@@ -57,16 +57,24 @@ function todo.maximize(player)
     return false
 end
 
-function todo.persist(element)
-    local frame = element.parent.parent
-
-    local task, should_add_to_top = todo.get_task_from_add_frame(frame)
+function todo.save_task(task, should_add_to_top)
     local add_index = #global.todo.open + 1
     if should_add_to_top then
         add_index = 1
     end
 
-    table.insert(global.todo.open, add_index, todo.create_task(task.task, task.assignee))
+    table.insert(global.todo.open, add_index, task)
+
+    return task
+end
+
+function todo.persist(element)
+    local frame = element.parent.parent
+
+    local task_spec, should_add_to_top = todo.get_task_from_add_frame(frame)
+    local task = todo.create_task(task_spec.task, task_spec.assignee)
+
+    todo.save_task(task, should_add_to_top)
 
     todo.log(serpent.block(global.todo))
     frame.destroy()
@@ -250,7 +258,7 @@ end
 
 function todo.move_bottom(id)
     local task = todo.get_task_by_id(id)
-    new_list = todo.filter_table_by_id(global.todo.open, id)
+    local new_list = todo.filter_table_by_id(global.todo.open, id)
     new_list[#new_list + 1] = task
     global.todo.open = new_list
 end

--- a/src/todo/todo.lua
+++ b/src/todo/todo.lua
@@ -89,15 +89,18 @@ function todo.get_task_from_add_frame(frame)
     end
 
     local should_add_to_top = false
-    local add_where_frame = frame.todo_add_button_flow.todo_add_where_frame
-
-    if add_where_frame and add_where_frame.todo_add_top.state then  -- 'Top' radio button
+    -- 'Add to Top' control won't exist in an edit dialog
+    local add_top_control = frame.todo_add_button_flow.todo_add_top
+    if add_top_control and add_top_control.state then
         should_add_to_top = true
     end
 
     local task = {["task"] = taskText, ["assignee"] = assignee}
 
     todo.log("Reading task " .. serpent.block(task))
+    if should_add_to_top then
+        todo.log("Adding it at the top.")
+    end
 
     return task, should_add_to_top
 end

--- a/src/todo/todo.lua
+++ b/src/todo/todo.lua
@@ -219,6 +219,19 @@ function todo.move(id, modifier)
     end
 end
 
+function todo.move_top(id)
+    local task = todo.get_task_by_id(id)
+    local new_list = {task}
+    global.todo.open =  todo.filter_table_by_id(global.todo.open, id, new_list)
+end
+
+function todo.move_bottom(id)
+    local task = todo.get_task_by_id(id)
+    new_list = todo.filter_table_by_id(global.todo.open, id)
+    new_list[#new_list + 1] = task
+    global.todo.open = new_list
+end
+
 function todo.on_gui_click(event)
     local player = game.players[event.player_index]
     local element = event.element
@@ -271,6 +284,16 @@ function todo.on_gui_click(event)
     elseif (string.find(element.name, "todo_item_down_")) then
         local id = todo.get_task_id_from_element_name(element.name, "todo_item_down_")
         todo.move_down(id)
+        todo.update_task_table()
+    elseif (string.find(element.name, "todo_item_top_")) then
+        local id = todo.get_task_id_from_element_name(element.name, "todo_item_top_")
+        todo.log('Moving task ' .. id .. ' to top.')
+        todo.move_top(id)
+        todo.update_task_table()
+    elseif (string.find(element.name, "todo_item_bottom_")) then
+        local id = todo.get_task_id_from_element_name(element.name, "todo_item_bottom_")
+        todo.log('Moving task ' .. id .. ' to bottom.')
+        todo.move_bottom(id)
         todo.update_task_table()
     elseif (string.find(element.name, "todo_")) then
         todo.log("Unknown todo element name:" .. element.name)


### PR DESCRIPTION
closes #40 

Implements buttons on the main UI to send a task to the top or bottom of the list.

<img width="357" alt="screenshot 2018-08-24 14 23 00" src="https://user-images.githubusercontent.com/569403/44601114-78a21580-a7a9-11e8-9e4e-10678df65d55.png">

Also adds a checkbox to the add task dialog to automatically add it to the top of the list.

<img width="451" alt="screenshot 2018-08-24 14 23 09" src="https://user-images.githubusercontent.com/569403/44601127-7d66c980-a7a9-11e8-8d57-e85145556e42.png">

I added a test for the 'top' button as well.  I tried to add a test case for the 'add to top' checkbox, but I couldn't get faktorio to actually check the box (`faketorio.click()` doesnt work :c )