### PR TITLE
First line of task text only in the maximise button

### DIFF
--- a/src/todo/todo.lua
+++ b/src/todo/todo.lua
@@ -147,7 +147,7 @@ function todo.update_current_task_label(player)
         if task.assignee == player.name then
             todo.log(serpent.block(task))
             todo.get_maximize_button(player).caption =
-                {"todo.todo_maximize_button_caption", {"todo.todo_list"}, task.task}
+                {"todo.todo_maximize_button_caption", {"todo.todo_list"}, string.gmatch(task.task, "%S+")()}
             return
         end
     end


### PR DESCRIPTION
Currently the maximise button shows all text from the task, including squarechars for newlines. This is ugly. This change shows only the first line of the task text in the maximise box.