### PR TITLE
focus the title field on new task dialog

### DIFF
--- a/src/todo/ui/add_dialog.lua
+++ b/src/todo/ui/add_dialog.lua
@@ -20,7 +20,7 @@ function todo.create_add_task_dialog(player)
         caption = { todo.translate(player, "add_task_title") }
     })
 
-    table.add({
+    local title_field = table.add({
         type = "textfield",
         style = "todo_textfield_default",
         name = "todo_new_task_title"
@@ -90,6 +90,7 @@ function todo.create_add_task_dialog(player)
     })
 
     dialog.force_auto_center()
+    title_field.focus()
 end
 
 function todo.get_add_dialog(player)


### PR DESCRIPTION
closes #177 

## Focus the task title field on new task popup
### Goal
prevent the use case where one clicks the add task button and starts typing, but the field isn't focused so they hit a bunch of hotkeys and have to close a bunch of windows and feel very silly.

### Questions/Feedback request
I dunno seems pretty straightforward to me.  ¯\\\_(ツ)_/¯
