### PR TITLE
Some UI Quality-of-Life tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,26 @@ find a small button in the upper left corner. Just click it or press shift-T :)
 
 ![minimized](https://github.com/JonasJurczok/factorio-todo-list/blob/master/img/minimized.png)
 
+There's also a couple of shortcuts you can add to your quickbar to toggle the
+Todo list UI or bring up the dialog to make a new task.
+
+To close the main frame, you can click the little x in the top-right, or press
+E or Esc to dismiss the ui, just like any other Factorio UI.  This does have a
+few edge cases detailed below:
+
+- If you press E or Esc to open a new dialog (or open a different UI e.g.
+Helmod), with the main todo list UI open, all todo list dialogs and UIs
+will close/minimize.
+- If you close the main ui any other way (x button, shortcut etc), and the add
+or edit dialog is open, the add or edit dialog will remain on screen, in
+case you were working on something. Import/export dialogs and the main
+frame will still close.
+- If you only have the add or edit dialog onscreen (i.e. main ui is minimized),
+they will also respect pressing E or Esc, (as long as a text field isn't
+active, as that will capture the E keystroke, Esc will work as expected)
+- If you only have the add or edit dialog onscreen (i.e. main ui is minimized),
+and you open the main UI, the add or edit dialog will close.
+
 ### Adding tasks
 
 Click the `Add` button to add a new task.
@@ -61,8 +81,8 @@ If you want to remove a task you can do that from the edit screen.
 Is the minimized UI (the "Todo List" button) still taking up your precious
 screen space?
 
-In the settings menu you can disable it. Then you'll only
-be able to use the hotkey (default shift-t) to show/hide the todo list.
+In the settings menu you can disable it. Then you'll only be able to use the
+hotkey (default shift-t) or the shortcut to show/hide the todo list.
 
 ## How to contribute?
 

--- a/src/control.lua
+++ b/src/control.lua
@@ -24,6 +24,7 @@ script.on_event(defines.events.on_gui_closed, function(event)
     if event.element and event.element.name == "todo_main_frame" then
         local player = game.get_player(event.player_index)
         todo.on_add_cancel_click(player)
+        todo.on_edit_cancel_click(player)
         todo.toggle_main_frame(player)
     end
 end)

--- a/src/control.lua
+++ b/src/control.lua
@@ -31,6 +31,9 @@ script.on_event(defines.events.on_gui_closed, function(event)
     elseif event.element and event.element.name == "todo_add_dialog" then
         local player = game.get_player(event.player_index)
         todo.on_add_cancel_click(player)
+    elseif event.element and event.element.name == "todo_edit_dialog" then
+        local player = game.get_player(event.player_index)
+        todo.on_edit_cancel_click(player)
     end
 end)
 

--- a/src/control.lua
+++ b/src/control.lua
@@ -23,6 +23,7 @@ end)
 script.on_event(defines.events.on_gui_closed, function(event)
     if event.element and event.element.name == "todo_main_frame" then
         local player = game.get_player(event.player_index)
+        todo.on_add_cancel_click(player)
         todo.toggle_main_frame(player)
     end
 end)

--- a/src/control.lua
+++ b/src/control.lua
@@ -20,6 +20,13 @@ script.on_event(defines.events.on_gui_click, function(event)
     todo.on_gui_click(event)
 end)
 
+script.on_event(defines.events.on_gui_closed, function(event)
+    if event.element and event.element.name == "todo_main_frame" then
+        local player = game.get_player(event.player_index)
+        todo.toggle_main_frame(player)
+    end
+end)
+
 script.on_event(defines.events.on_lua_shortcut, function(event)
     todo.on_lua_shortcut(event)
 end)

--- a/src/control.lua
+++ b/src/control.lua
@@ -28,6 +28,9 @@ script.on_event(defines.events.on_gui_closed, function(event)
         todo.on_import_cancel_click(player)
         todo.on_export_cancel_click(player)
         todo.minimize_main_frame(player)
+    elseif event.element and event.element.name == "todo_add_dialog" then
+        local player = game.get_player(event.player_index)
+        todo.on_add_cancel_click(player)
     end
 end)
 

--- a/src/control.lua
+++ b/src/control.lua
@@ -25,7 +25,9 @@ script.on_event(defines.events.on_gui_closed, function(event)
         local player = game.get_player(event.player_index)
         todo.on_add_cancel_click(player)
         todo.on_edit_cancel_click(player)
-        todo.toggle_main_frame(player)
+        todo.on_import_cancel_click(player)
+        todo.on_export_cancel_click(player)
+        todo.minimize_main_frame(player)
     end
 end)
 

--- a/src/todo/features/main_ui.lua
+++ b/src/todo/features/main_ui.lua
@@ -39,7 +39,7 @@ function todo.maximize_main_frame(player)
 
     if not todo.get_main_frame(player) then
         frame = todo.create_maximized_frame(player)
-		player.opened = frame
+        player.opened = frame
         return true
     end
     return false

--- a/src/todo/features/main_ui.lua
+++ b/src/todo/features/main_ui.lua
@@ -38,7 +38,8 @@ function todo.maximize_main_frame(player)
     player.set_shortcut_toggled("todo-toggle-ui-shortcut", true)
 
     if not todo.get_main_frame(player) then
-        todo.create_maximized_frame(player)
+        frame = todo.create_maximized_frame(player)
+		player.opened = frame
         return true
     end
     return false

--- a/src/todo/features/main_ui.lua
+++ b/src/todo/features/main_ui.lua
@@ -18,6 +18,26 @@ function todo.minimize_main_frame(player)
     local frame = todo.get_main_frame(player)
     if frame then
         frame.destroy()
+
+        -- just close import/export
+        if (todo.get_import_dialog(player)) then
+            todo.on_import_cancel_click(player)
+        end
+        if (todo.get_export_dialog(player)) then
+            todo.on_export_cancel_click(player)
+        end
+
+        -- if other dialog open, set it to opened
+        local dialog = todo.get_add_dialog(player)
+        if (dialog) then
+            player.opened = dialog
+            return true
+        end
+        dialog = todo.get_edit_dialog(player)
+        if (dialog) then
+            player.opened = dialog
+            return true
+        end
         return true
     end
     return false

--- a/src/todo/ui/add_dialog.lua
+++ b/src/todo/ui/add_dialog.lua
@@ -91,6 +91,8 @@ function todo.create_add_task_dialog(player)
 
     dialog.force_auto_center()
     title_field.focus()
+
+    return dialog
 end
 
 function todo.get_add_dialog(player)

--- a/src/todo/ui/add_dialog.lua
+++ b/src/todo/ui/add_dialog.lua
@@ -91,8 +91,6 @@ function todo.create_add_task_dialog(player)
 
     dialog.force_auto_center()
     title_field.focus()
-
-    return dialog
 end
 
 function todo.get_add_dialog(player)

--- a/src/todo/ui/add_dialog.lua
+++ b/src/todo/ui/add_dialog.lua
@@ -91,6 +91,11 @@ function todo.create_add_task_dialog(player)
 
     dialog.force_auto_center()
     title_field.focus()
+
+    -- if main frame is not active, set this to player.opened
+    if not todo.get_main_frame(player) then
+        player.opened = dialog
+    end
 end
 
 function todo.get_add_dialog(player)

--- a/src/todo/ui/edit_dialog.lua
+++ b/src/todo/ui/edit_dialog.lua
@@ -26,7 +26,7 @@ function todo.create_edit_task_dialog(player, id)
         caption = { todo.translate(player, "add_task_title") }
     })
 
-    table.add({
+    local title_field = table.add({
         type = "textfield",
         style = "todo_textfield_default",
         name = "todo_edit_task_title",
@@ -133,6 +133,7 @@ function todo.create_edit_task_dialog(player, id)
     })
 
     dialog.force_auto_center()
+    title_field.focus()
 end
 
 function todo.get_edit_dialog(player)

--- a/src/todo/ui/main_frame.lua
+++ b/src/todo/ui/main_frame.lua
@@ -59,7 +59,7 @@ function todo.create_maximized_frame(player)
 
     frame.force_auto_center()
 
-	return frame
+    return frame
 end
 
 function todo.create_task_table(frame, player)

--- a/src/todo/ui/main_frame.lua
+++ b/src/todo/ui/main_frame.lua
@@ -58,6 +58,8 @@ function todo.create_maximized_frame(player)
     })
 
     frame.force_auto_center()
+
+	return frame
 end
 
 function todo.create_task_table(frame, player)


### PR DESCRIPTION
## Close UIs on pressing E or Escape
### Goal
Most UIs in Factorio automatically close if you open another UI or press E or Esc.  Unfortunately, the UIs from this mod do not, so they always have to be manually closed.  The goal is to improve this mod's usability by conforming to that convention.

I also made it so that the edit dialog's title field gets focus when it's opened, same as with the add dialog.

### Questions/Feedback request
I manually tested this a bunch, and all of the edge cases (detailed in the README) were identified and resolved entirely on my own judgement, which is far from perfect.  I'm looking for feedback on how I handled those edge cases, as well as my implementation in general.  I'm not really a Lua developer, so I've probably made some rookie mistakes.

I also didn't touch the tests at all.  I would like to add some automated tests for this, but as I said, I have almost no Lua experience (in fact, all of the Lua code I've written is in this repo :p), so I didn't want to get rabbit-holed on that. I do plan to add some when I get around to learning about how the tests here work, but I wanted to get this code in front of somebody else for review ASAP. 