### PR TITLE
ci: Add storage to allowed globals

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,4 +1,4 @@
-globals = {"todo", "mod_gui", "script", "game", "defines", "data", "serpent", "settings", "global"}
+globals = {"todo", "mod_gui", "script", "game", "defines", "data", "serpent", "settings", "global", "storage"}
 read_globals = {
     os = {
         fields = {

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,4 +1,4 @@
-globals = {"todo", "mod_gui", "script", "game", "defines", "data", "serpent", "settings", "global", "storage"}
+globals = {"todo", "mod_gui", "script", "game", "defines", "data", "serpent", "settings", "storage"}
 read_globals = {
     os = {
         fields = {


### PR DESCRIPTION
## Luacheck fix
### Goal
The luacheck fails because storage is not defined as global
### Questions/Feedback request
N/A
