### PR TITLE
Add tasks/subtasks on enter press

### DIFF
--- a/src/control.lua
+++ b/src/control.lua
@@ -39,6 +39,10 @@ script.on_event(defines.events.on_gui_closed, function(event)
     end
 end)
 
+script.on_event(defines.events.on_gui_confirmed, function(event)
+    todo.on_gui_confirmed(event)
+end)
+
 script.on_event(defines.events.on_lua_shortcut, function(event)
     todo.on_lua_shortcut(event)
 end)

--- a/src/todo/todo.lua
+++ b/src/todo/todo.lua
@@ -203,6 +203,25 @@ function todo.on_gui_click(event)
     end
 end
 
+function todo.on_gui_confirmed(event)
+    local player = game.players[event.player_index]
+    local element = event.element
+    local name = element.name
+    if (element.name == "todo_new_task_title") then
+        todo.on_save_new_task_click(player)
+        todo.log('tried saving task on enter')
+        if(todo.get_keep_adding_tasks(player)) then
+            todo.create_add_task_dialog(player)
+        end
+    elseif (string.find(element.name, "todo_main_subtask_new_text_")) then
+        local id = todo.get_task_id_from_element_name(element.name, "todo_main_subtask_new_text_")
+        todo.on_save_new_subtask_click(player, id)
+        if (player.opened.valid) then
+            player.opened.todo_scroll_pane.todo_task_table[name].focus()
+        end
+    end
+end
+
 function todo.on_lua_shortcut(event)
     local player = game.players[event.player_index]
 

--- a/src/todo/todo.lua
+++ b/src/todo/todo.lua
@@ -217,7 +217,9 @@ function todo.on_gui_confirmed(event)
         local id = todo.get_task_id_from_element_name(element.name, "todo_main_subtask_new_text_")
         todo.on_save_new_subtask_click(player, id)
         if (player.opened.valid) then
-            player.opened.todo_scroll_pane.todo_task_table[name].focus()
+            if (player.opened.todo_scroll_pane.todo_task_table[name]) then
+                player.opened.todo_scroll_pane.todo_task_table[name].focus()
+            end
         end
     end
 end


### PR DESCRIPTION
Added the ability to .

## Add tasks/subtasks on enter press
### Goal
Added the ability to submit tasks or subtasks on enter pressed while the textbox was highlighted.
Also focuses on the next subtasks under the task when a subtask is submitted in this way. 
