### PR TITLE
Fix get nil task crash

### DIFF
--- a/src/todo/features/edit_task.lua
+++ b/src/todo/features/edit_task.lua
@@ -40,6 +40,9 @@ function todo.edit_persist_task_changes(player, id)
     todo.log("Player " .. player.name .. " updates task " .. id)
 
     local original = todo.get_task_by_id(id)
+    if (original == nil) then
+        return
+    end
 
     original.title = dialog.todo_edit_task_table["todo_edit_task_title"].text
     original.task = dialog.todo_edit_task_table["todo_edit_task_textbox"].text


### PR DESCRIPTION
## Fix get nil task crash
### Goal
Fixed a bug in multiplayer mode involving the use of the to-do list that caused the game to crash immediately.

### Questions/Feedback request
<img width="1648" height="1042" alt="DF4200688B00056AED2A0626A9CAE605" src="https://github.com/user-attachments/assets/6fa878ec-6817-400c-b2a6-8d06c024770e" />
Following testing, we hypothesise this bug arises as follows:
1. The to-do list already contains task1, then both Player A and Player B open the window
2. Player A deletes task1 and clicks save
3. Player B clicks save
At this point, the game encounters a nil error because task1 cannot be found for Player B, subsequently causing the game to crash
I am not particularly familiar with the todo-list code; if you have a better method for fixing this, that would be most welcome.