### PR TITLE
fix: nil guard all task/subtask lookup call sites

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,12 @@
 ---------------------------------------------------------------------------------------------------
+Version: 19.15.2
+Date: 2026-05-20
+  Bugfixes:
+    - Fixed non-recoverable crash when interacting with a task or subtask that was deleted by another player while a dialog was open (multiplayer race condition).
+    - Ghost tasks/subtasks now disappear immediately from all players' UI when the stale interaction is detected.
+    - Added player notifications when a subtask could not be saved or edited because the parent task or subtask no longer exists.
+    - Export dialog now notifies the player when selected tasks were excluded because they no longer exist.
+---------------------------------------------------------------------------------------------------
 Version: 19.15.1
 Date: 2026-05-20
   Bugfixes:

--- a/src/info.json
+++ b/src/info.json
@@ -1,6 +1,6 @@
 {
   "name": "Todo-List",
-  "version": "19.15.1",
+  "version": "19.15.2",
   "title": "✔ Todo List",
   "author": "Jason Miles and many others from the community",
   "contact": "jonasjurczok+factorio@gmail.com",

--- a/src/locale/en/default.cfg
+++ b/src/locale/en/default.cfg
@@ -49,6 +49,10 @@ search_tooltip=Type to filter tasks by title or description (Ctrl+F / Cmd+F)
 clear_search=Clear search
 no_results=No tasks match your search
 
+error_task_deleted=This task no longer exists.
+error_subtask_deleted=This subtask no longer exists.
+error_export_skipped=One or more selected tasks no longer exist and were excluded from the export.
+
 clean=Clean
 clean_title=Clean tasks
 clean_option_completed=Completed tasks

--- a/src/todo/features/export_task.lua
+++ b/src/todo/features/export_task.lua
@@ -28,7 +28,9 @@ function todo.generate_and_show_export_string(player)
         if (i % 2 == 1 and checkbox.state) then
             local id = todo.get_task_id_from_element_name(checkbox.name, "todo_export_select_task_checkbox_")
             local task = todo.get_task_by_id(id)
-            table.insert(tasks, task)
+            if task then
+                table.insert(tasks, task)
+            end
         end
     end
 

--- a/src/todo/features/export_task.lua
+++ b/src/todo/features/export_task.lua
@@ -22,6 +22,7 @@ function todo.generate_and_show_export_string(player)
     local tasks_table = dialog.todo_export_dialog_scroll_pane.todo_export_dialog_table
 
     local tasks = {}
+    local has_missing = false
 
     for i, checkbox in ipairs(tasks_table.children) do
         -- every uneven child is a textbox (lists start at 1)
@@ -30,8 +31,14 @@ function todo.generate_and_show_export_string(player)
             local task = todo.get_task_by_id(id)
             if task then
                 table.insert(tasks, task)
+            else
+                has_missing = true
             end
         end
+    end
+
+    if has_missing then
+        player.print({"todo.error_export_skipped"})
     end
 
     -- if no tasks are selected, remove the textbox

--- a/src/todo/features/export_task.lua
+++ b/src/todo/features/export_task.lua
@@ -25,7 +25,7 @@ function todo.generate_and_show_export_string(player)
     local has_missing = false
 
     for i, checkbox in ipairs(tasks_table.children) do
-        -- every uneven child is a textbox (lists start at 1)
+        -- every odd child is a checkbox, even child is a label (lists start at 1)
         if (i % 2 == 1 and checkbox.state) then
             local id = todo.get_task_id_from_element_name(checkbox.name, "todo_export_select_task_checkbox_")
             local task = todo.get_task_by_id(id)

--- a/src/todo/features/subtasks.lua
+++ b/src/todo/features/subtasks.lua
@@ -67,7 +67,18 @@ function todo.on_edit_subtask_save_click(player, task_id, subtask_id)
 
     local new_text = dialog.todo_edit_subtask_text.text
 
-    todo.update_subtask(task_id, subtask_id, new_text)
+    local task = todo.get_task_by_id(task_id)
+    if not task then
+        player.print({"todo.error_task_deleted"})
+        dialog.destroy()
+        todo.update_main_task_list_for_everyone()
+        return
+    end
+
+    local ok = todo.update_subtask(task_id, subtask_id, new_text)
+    if not ok then
+        player.print({"todo.error_subtask_deleted"})
+    end
 
     dialog.destroy()
 
@@ -76,11 +87,12 @@ end
 
 function todo.update_subtask(task_id, subtask_id, new_text)
     local task = todo.get_task_by_id(task_id)
-    if not task then return end
+    if not task then return false end
     local subtask = todo.get_subtask_by_id(task, subtask_id)
-    if not subtask then return end
+    if not subtask then return false end
 
     subtask.task = new_text
+    return true
 end
 
 function todo.on_subtask_checkbox_click(task_id, subtask_id)
@@ -89,8 +101,8 @@ function todo.on_subtask_checkbox_click(task_id, subtask_id)
         todo.update_main_task_list_for_everyone()
         return
     end
-    local _, is_completed = todo.get_subtask_by_id(task, subtask_id)
-    if not _ then
+    local subtask, is_completed = todo.get_subtask_by_id(task, subtask_id)
+    if not subtask then
         todo.update_main_task_list_for_everyone()
         return
     end
@@ -162,8 +174,8 @@ function todo.on_subtask_delete_click(task_id, subtask_id)
         todo.update_main_task_list_for_everyone()
         return
     end
-    local _, is_completed = todo.get_subtask_by_id(task, subtask_id)
-    if not _ then
+    local subtask, is_completed = todo.get_subtask_by_id(task, subtask_id)
+    if not subtask then
         todo.update_main_task_list_for_everyone()
         return
     end

--- a/src/todo/features/subtasks.lua
+++ b/src/todo/features/subtasks.lua
@@ -5,6 +5,7 @@
 function todo.on_save_new_subtask_click(player, task_id)
 
     local task = todo.get_task_by_id(task_id)
+    if not task then return end
 
     local task_table = todo.get_task_table(player)
     local textfield = task_table["todo_main_subtask_new_text_" .. task_id]
@@ -35,7 +36,9 @@ end
 
 function todo.on_edit_subtask_click(player, task_id, subtask_id)
     local task = todo.get_task_by_id(task_id)
+    if not task then return end
     local subtask = todo.get_subtask_by_id(task, subtask_id)
+    if not subtask then return end
 
     todo.create_edit_subtask_dialog(player, task.id, subtask)
 end
@@ -61,14 +64,18 @@ end
 
 function todo.update_subtask(task_id, subtask_id, new_text)
     local task = todo.get_task_by_id(task_id)
+    if not task then return end
     local subtask = todo.get_subtask_by_id(task, subtask_id)
+    if not subtask then return end
 
     subtask.task = new_text
 end
 
 function todo.on_subtask_checkbox_click(task_id, subtask_id)
     local task = todo.get_task_by_id(task_id)
+    if not task then return end
     local _, is_completed = todo.get_subtask_by_id(task, subtask_id)
+    if not _ then return end
 
     if (is_completed) then
         todo.mark_subtask_open(task, subtask_id)
@@ -119,6 +126,7 @@ end
 
 function todo.move_subtask(task_id, subtask_id, modifier)
     local task = todo.get_task_by_id(task_id)
+    if not task then return end
     for i, subtask in pairs(task.subtasks.open) do
         if (subtask.id == subtask_id) then
             local copy = task.subtasks.open[i + modifier]
@@ -132,7 +140,9 @@ end
 function todo.on_subtask_delete_click(task_id, subtask_id)
 
     local task = todo.get_task_by_id(task_id)
+    if not task then return end
     local _, is_completed = todo.get_subtask_by_id(task, subtask_id)
+    if not _ then return end
 
     if (is_completed) then
         todo.delete_subtask(task.subtasks.done, subtask_id)

--- a/src/todo/features/subtasks.lua
+++ b/src/todo/features/subtasks.lua
@@ -5,7 +5,11 @@
 function todo.on_save_new_subtask_click(player, task_id)
 
     local task = todo.get_task_by_id(task_id)
-    if not task then return end
+    if not task then
+        player.print({"todo.error_task_deleted"})
+        todo.update_main_task_list_for_everyone()
+        return
+    end
 
     local task_table = todo.get_task_table(player)
     local textfield = task_table["todo_main_subtask_new_text_" .. task_id]
@@ -36,9 +40,17 @@ end
 
 function todo.on_edit_subtask_click(player, task_id, subtask_id)
     local task = todo.get_task_by_id(task_id)
-    if not task then return end
+    if not task then
+        player.print({"todo.error_task_deleted"})
+        todo.update_main_task_list_for_everyone()
+        return
+    end
     local subtask = todo.get_subtask_by_id(task, subtask_id)
-    if not subtask then return end
+    if not subtask then
+        player.print({"todo.error_subtask_deleted"})
+        todo.update_main_task_list_for_everyone()
+        return
+    end
 
     todo.create_edit_subtask_dialog(player, task.id, subtask)
 end
@@ -73,9 +85,15 @@ end
 
 function todo.on_subtask_checkbox_click(task_id, subtask_id)
     local task = todo.get_task_by_id(task_id)
-    if not task then return end
+    if not task then
+        todo.update_main_task_list_for_everyone()
+        return
+    end
     local _, is_completed = todo.get_subtask_by_id(task, subtask_id)
-    if not _ then return end
+    if not _ then
+        todo.update_main_task_list_for_everyone()
+        return
+    end
 
     if (is_completed) then
         todo.mark_subtask_open(task, subtask_id)
@@ -140,9 +158,15 @@ end
 function todo.on_subtask_delete_click(task_id, subtask_id)
 
     local task = todo.get_task_by_id(task_id)
-    if not task then return end
+    if not task then
+        todo.update_main_task_list_for_everyone()
+        return
+    end
     local _, is_completed = todo.get_subtask_by_id(task, subtask_id)
-    if not _ then return end
+    if not _ then
+        todo.update_main_task_list_for_everyone()
+        return
+    end
 
     if (is_completed) then
         todo.delete_subtask(task.subtasks.done, subtask_id)

--- a/src/todo/features/take_task.lua
+++ b/src/todo/features/take_task.lua
@@ -6,7 +6,10 @@ function todo.on_take_task_click(player, id)
     todo.log("Assigning task " .. id .. " to player " .. player.name)
 
     local task = todo.get_task_by_id(id)
-    if not task then return end
+    if not task then
+        todo.update_main_task_list_for_everyone()
+        return
+    end
     task.assignee = player.name
 
     todo.update_main_task_list_for_everyone()

--- a/src/todo/features/take_task.lua
+++ b/src/todo/features/take_task.lua
@@ -6,6 +6,7 @@ function todo.on_take_task_click(player, id)
     todo.log("Assigning task " .. id .. " to player " .. player.name)
 
     local task = todo.get_task_by_id(id)
+    if not task then return end
     task.assignee = player.name
 
     todo.update_main_task_list_for_everyone()


### PR DESCRIPTION
## Summary

- `get_task_by_id` and `get_subtask_by_id` both return `nil` when the target no longer exists
- In multiplayer, another player can delete a task/subtask between a dialog opening and the player acting on it (save, checkbox, delete, move), causing a non-recoverable nil-index crash
- Added early-return nil guards after every unguarded call site across `subtasks.lua`, `take_task.lua`, and `export_task.lua`

Closes #152

## Test plan

- [ ] Open subtask edit dialog in multiplayer, have another player delete the subtask, then click Save — should silently close dialog, no crash
- [ ] Same for task deletion while subtask dialog is open
- [ ] Check/uncheck, delete, and move subtasks still work normally in single-player
- [ ] Export dialog with tasks that get deleted mid-interaction