### PR TITLE
ci: upgrade factorio-mod-uploader-action v1 → v2 (Node 24 fix)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,6 +46,7 @@ jobs:
           with:
               action: compress
               mod-folder: src
+              auto-update-version: 'false'
 
         - name: Upload ZIP as Artifact
           uses: actions/upload-artifact@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,22 +35,17 @@ jobs:
         - name: Copy changelog into mod folder
           run: cp changelog.txt src/changelog.txt
 
-        - name: Set up Node.js
-          uses: actions/setup-node@v3
-          with:
-              node-version: '20'
-
         - name: Validate Mod
-          uses: TheBrutalX/factorio-mod-uploader-action@v1
+          uses: TheBrutalX/factorio-mod-uploader-action@v2
           with:
               action: validate
               mod-folder: src
 
         - name: Create zip
-          uses: TheBrutalX/factorio-mod-uploader-action@v1
+          uses: TheBrutalX/factorio-mod-uploader-action@v2
           with:
               action: compress
-              mod-folder: src          
+              mod-folder: src
 
         - name: Upload ZIP as Artifact
           uses: actions/upload-artifact@v4

--- a/.github/workflows/publish_to_factorio.yml
+++ b/.github/workflows/publish_to_factorio.yml
@@ -17,19 +17,14 @@ jobs:
             - name: Copy changelog into mod folder
               run: cp changelog.txt src/changelog.txt
 
-            - name: Set up Node.js
-              uses: actions/setup-node@v3
-              with:
-                  node-version: '20'
-
             - name: Validate Mod
-              uses: TheBrutalX/factorio-mod-uploader-action@v1
+              uses: TheBrutalX/factorio-mod-uploader-action@v2
               with:
                   action: validate
                   mod-folder: src
 
             - name: Create zip
-              uses: TheBrutalX/factorio-mod-uploader-action@v1
+              uses: TheBrutalX/factorio-mod-uploader-action@v2
               with:
                   action: compress
                   mod-folder: src
@@ -38,11 +33,11 @@ jobs:
               uses: actions/upload-artifact@v4
               with:
                 name: factorio-mod-zip
-                path: ${{ env.ZIP_FILE }}
+                path: ${{ env.PROCESS_ZIP_FILE }}
 
             - name: Upload Mod
               if: startsWith(github.ref, 'refs/tags/v')
-              uses: TheBrutalX/factorio-mod-uploader-action@v1
+              uses: TheBrutalX/factorio-mod-uploader-action@v2
               with:
                   action: upload
                   factorio-api-key: ${{ secrets.FACTORIO_API_KEY }}
@@ -51,5 +46,5 @@ jobs:
               if: startsWith(github.ref, 'refs/tags/v')
               uses: softprops/action-gh-release@v2
               with:
-                  files: ${{ env.ZIP_FILE }}
+                  files: ${{ env.PROCESS_ZIP_FILE }}
                   generate_release_notes: false

--- a/.github/workflows/publish_to_factorio.yml
+++ b/.github/workflows/publish_to_factorio.yml
@@ -33,7 +33,7 @@ jobs:
               uses: actions/upload-artifact@v4
               with:
                 name: factorio-mod-zip
-                path: ${{ env.PROCESS_ZIP_FILE }}
+                path: ${{ env.ZIP_FILE }}
 
             - name: Upload Mod
               if: startsWith(github.ref, 'refs/tags/v')
@@ -46,5 +46,5 @@ jobs:
               if: startsWith(github.ref, 'refs/tags/v')
               uses: softprops/action-gh-release@v2
               with:
-                  files: ${{ env.PROCESS_ZIP_FILE }}
+                  files: ${{ env.ZIP_FILE }}
                   generate_release_notes: false

--- a/.github/workflows/publish_to_factorio.yml
+++ b/.github/workflows/publish_to_factorio.yml
@@ -28,6 +28,7 @@ jobs:
               with:
                   action: compress
                   mod-folder: src
+                  auto-update-version: 'false'
 
             - name: Upload ZIP as Artifact
               uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- Upgrades \`TheBrutalX/factorio-mod-uploader-action\` from \`@v1\` to \`@v2\` in both publish and CI workflows
- Removes \`actions/setup-node@v3\` steps (v2 is self-contained with Node 24)
- Explicitly sets \`auto-update-version: 'false'\` on compress steps (v2 requires this input)
- \`ZIP_FILE\` env var name unchanged — v2 still exports it as \`ZIP_FILE\`

## Root cause

GitHub Actions now forces Node 24 on all actions. \`@v1\` targets Node 20 and crashes with an unhandled exception after printing "Mod uploaded successfully" — the upload never completes. \`@v2\` targets Node 24 natively and is a drop-in replacement.

## Test plan

- [ ] Merge and re-run publish workflow on \`v19.15.3\` tag (or retag) to verify mod uploads to portal and GitHub Release is created
- [ ] Verify artifact upload step works with \`ZIP_FILE\`