### PR TITLE
fix: correct factorio_version format in info.json

### DIFF
--- a/src/info.json
+++ b/src/info.json
@@ -5,7 +5,7 @@
   "author": "Jason Miles and many others from the community",
   "contact": "jonasjurczok+factorio@gmail.com",
   "homepage": "https://github.com/JonasJurczok/factorio-todo-list",
-  "factorio_version": "2.1.8",
+  "factorio_version": "2.1",
   "dependencies": [
     "base >= 2.0.0"
   ],


### PR DESCRIPTION
## Summary

- Changes `factorio_version` from `"2.1.8"` to `"2.1"` in `src/info.json`

## Root cause

The Factorio mod portal rejects uploads where `factorio_version` has three numbers. The spec explicitly requires `major.minor` format only (e.g. `"2.1"`). This was causing `Invalid mod data in zipfile` errors on every publish attempt despite the zip being valid.

## Test plan

- [ ] Merge and retag v19.15.3 — publish workflow should succeed and mod should appear on the portal